### PR TITLE
chore(api): add companies migration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "api",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "migration:run": "typeorm-ts-node-commonjs migration:run -d src/data-source.ts"
+  },
+  "dependencies": {
+    "mysql2": "^3.3.0",
+    "typeorm": "^0.3.17"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1"
+  }
+}

--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -1,0 +1,16 @@
+import { DataSource } from 'typeorm';
+
+export const AppDataSource = new DataSource({
+  type: 'mysql',
+  host: process.env.DB_HOST || 'localhost',
+  port: Number(process.env.DB_PORT) || 3306,
+  username: process.env.DB_USERNAME || 'root',
+  password: process.env.DB_PASSWORD || '',
+  database: process.env.DB_NAME || 'tali',
+  synchronize: false,
+  logging: false,
+  entities: [],
+  migrations: ['src/migrations/*{.ts,.js}'],
+});
+
+export default AppDataSource;

--- a/apps/api/src/migrations/1685732741932-CreateCompanies.ts
+++ b/apps/api/src/migrations/1685732741932-CreateCompanies.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateCompanies1685732741932 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE companies (
+        id VARCHAR(36) PRIMARY KEY,
+        name VARCHAR(255) NOT NULL,
+        industry VARCHAR(100),
+        health_score DECIMAL(5,2) DEFAULT 0.0,
+        risk_segment VARCHAR(50),
+        last_assessment_at DATETIME,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        INDEX idx_industry (industry),
+        INDEX idx_risk_segment (risk_segment)
+      );
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE companies;`);
+  }
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold initial TypeORM migration for companies table
- configure TypeORM data source for MySQL and migrations
- add API package config with migration run script

## Testing
- `npx typeorm-ts-node-commonjs migration:run -d src/data-source.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/typeorm-ts-node-commonjs)*

------
https://chatgpt.com/codex/tasks/task_e_6892606fdadc8331a38a215842a00ce9