### PR TITLE
feat(api): add companies controller

### DIFF
--- a/apps/api/src/companies/companies.controller.ts
+++ b/apps/api/src/companies/companies.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
+import { CompaniesService } from './companies.service';
+import { Company } from './companies.entity';
+
+@Controller('companies')
+export class CompaniesController {
+  constructor(private readonly companiesService: CompaniesService) {}
+
+  @Get()
+  findAll(): Promise<Company[]> {
+    return this.companiesService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<Company | null> {
+    return this.companiesService.findOne(id);
+  }
+
+  @Post()
+  create(@Body() data: Partial<Company>): Promise<Company> {
+    return this.companiesService.create(data);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() data: Partial<Company>): Promise<Company | null> {
+    return this.companiesService.update(id, data);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string): Promise<void> {
+    return this.companiesService.remove(id);
+  }
+}


### PR DESCRIPTION
## Summary
- add CompaniesController to expose CRUD routes for company entity

## Testing
- `npm test` *(fails: Could not resolve workspaces. Missing `packageManager` field in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689267416efc8331a185d46f48fd58f4